### PR TITLE
Add Omen 15-en1xxx compatibility + early build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # omen-fan
 - A simple utility to manually control the fans of a HP Omen laptop
 - Works on various HP Omen laptop and even some Victus laptops from testing. 
-- Also has a service that actively adjusts the fan speed according to tempertatures (cause the default BIOS control sucks)
+- Also has a service that actively adjusts the fan speed according to temperatures (cause the default BIOS control sucks)
 - Supports enabling boost mode via sysfs
 - Made and tested on an Omen 16-c0140AX
-- Rust made and tested on Omen 16-n0xxx series and Omen 15-dc10xxxx
+- Rust made and tested on Omen 16-n0xxx series, Omen 15-dc1xxxx and Omen 15-en1xxx
 
 # WARNING
 - Forcing this program to run on incompatible laptops may cause hardware damage. Use at your own risk.
@@ -14,8 +14,17 @@
 - Use `omen-fan help` to see all available subcommands
 - EC Probe documentation can be found at [docs/probes.md](https://github.com/alou-S/omen-fan/blob/main/docs/probes.md)
 
+# Building
+( Guide based on Ubuntu 25.04 )
+- Install rustup and configure it to the nightly channel
+    - sudo apt install rustup
+    - rustup default nightly
+- Go into the omen-fan directory and build the project for release
+    - cd omen-fan
+    - rustup.cargo build --release
+
 # Silverblue
--copy the target from release folder
--sudo cp /var/home/user-name/omen-fan/omen-fan/target/release/omen-fan /usr/local/bin/
+- copy the target from release folder
+- sudo cp /var/home/user-name/omen-fan/omen-fan/target/release/omen-fan /usr/local/bin/
 replace user
---Then add service file to the system.
+- Then add service file to the system.


### PR DESCRIPTION
Hi,

Following the emails I send last week.

Here is my contribution to your project.

I was a little bit stupid and forgot to check 0x34 and 0x35 registers with a value.
Without setting a value ourselves this registers have no value but that's normal and that made me believe they where not compatible with my variant of the Omen 15...

Also, after some research I understood how to build the project with rust and cargo.
I made a little guide for the Ubuntu distros so that it's easier to compile for everyone.